### PR TITLE
fix for invalid project path in windows

### DIFF
--- a/lib/project-quick-open-view.coffee
+++ b/lib/project-quick-open-view.coffee
@@ -35,8 +35,8 @@ class ProjectQuickOpenView extends SelectListView
     projectPath = '~'
     if atom.config.get('project-quick-open.projectPaths') && atom.config.get('project-quick-open.projectPaths') != '~'
       projectPath = atom.config.get('project-quick-open.projectPaths')
-    else if atom.config.settings.core.projectHome
-      projectPath = atom.config.settings.core.projectHome
+    else if atom.config.getSettings().core.projectHome
+      projectPath = atom.config.getSettings().core.projectHome
 
     projectPath = if projectPath.slice(-1) != '/' then projectPath + '/' else projectPath
 


### PR DESCRIPTION
atom.config.settings.core.projectHome returns undefined if no project home has been set in core settings
atom.config.getSettings().core.projectHome will return the default home location if none has been set or the user defined home if it has