### PR TITLE
Updating package because of Deprecation Cop errors

### DIFF
--- a/keymaps/project-quick-open.cson
+++ b/keymaps/project-quick-open.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'.atom-workspace':
   'ctrl-alt-p': 'project-quick-open:toggle'


### PR DESCRIPTION
The recommendation from Atom is to use the `.atom-workspace` tag instead of `.workspace`:

![project-quick-open](https://cloud.githubusercontent.com/assets/275617/5961098/00677506-a78f-11e4-901d-2e23a0bb0aca.png)
