### PR TITLE
Prevent atom.open from reusing an existing window

### DIFF
--- a/lib/project-quick-open-view.coffee
+++ b/lib/project-quick-open-view.coffee
@@ -27,7 +27,10 @@ class ProjectQuickOpenView extends SelectListView
       atom.project.setPath(newPath)
     else
       # open in new window
-      atom.open({ pathsToOpen: [newPath] })
+      atom.open(
+        pathsToOpen: [newPath],
+        newWindow: true
+      )
     @cancel()
 
   getProjectPath: (cb) ->


### PR DESCRIPTION
Before, when first opening Atom and selecting a project it used to reuse the existing empty window. This prevented Atom from loading the saved workspace until the project was selected a second time.
